### PR TITLE
Avoid s3 rate limiting

### DIFF
--- a/behold.py
+++ b/behold.py
@@ -28,7 +28,7 @@ logger = logging.getLogger("main")
 # Reading metadata, performing metadata validation, initializing required classes.
 meta = metadata.read(args.metadata)
 boto = utils.Boto(meta)
-meta = metadata.set_defaults(meta)
+meta = metadata.set_defaults(meta, boto)
 s3 = S3(meta, boto.session)
 athena = Athena(meta, boto.session)
 csv = CSVParser()

--- a/behold.py
+++ b/behold.py
@@ -1,4 +1,5 @@
 from libs import metadata
+from libs import utils
 from libs.athena import Athena
 from libs.s3 import S3
 from libs.csv_parser import CSVParser
@@ -24,9 +25,12 @@ logging.basicConfig(
 )
 logger = logging.getLogger("main")
 
+# Reading metadata, performing metadata validation, initializing required classes.
 meta = metadata.read(args.metadata)
-s3 = S3(meta)
-athena = Athena(meta)
+boto = utils.Boto(meta)
+meta = metadata.set_defaults(meta)
+s3 = S3(meta, boto.session)
+athena = Athena(meta, boto.session)
 csv = CSVParser()
 policygen = PolicyGenerator()
 

--- a/libs/athena.py
+++ b/libs/athena.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 class Athena():
     """ Class for interacting with Athena service in AWS. """
-    def __init__(self, metadata):
+    def __init__(self, metadata, session=None):
         """ Sets required variables.  Creates Athena boto3 client. """
         self.metadata = metadata
         self.accounts = metadata['accounts_to_partition']
@@ -16,7 +16,7 @@ class Athena():
         self.cloudtrail_bucket = metadata['cloudtrail_bucket']
         self.behold_bucket = metadata['behold_bucket']
         self.region = metadata['region']
-        self.create_client()
+        self.create_client(session)
 
     def active_resources(self):
         """ Creates list objects which are used to store location to Athena output files.
@@ -26,9 +26,12 @@ class Athena():
         self.active_roles_query()
         self.active_users_query()
 
-    def create_client(self):
+    def create_client(self, session):
         """ Creates Athena boto3 client. """
-        self.client = boto3.client('athena', region_name=self.region)
+        if session is None:
+            self.client = boto3.client('athena', region_name=self.region)
+        else:
+            self.client = session.client('athena')
 
     def start_query_execution(self, query_string, path):
         """ Takes Athena query string and output path and executes the query. """

--- a/libs/athena.py
+++ b/libs/athena.py
@@ -1,6 +1,7 @@
 import boto3
 import logging
 from . import athena_query_strings
+from . import s3
 from . import utils
 
 logger = logging.getLogger(__name__)
@@ -16,6 +17,7 @@ class Athena():
         self.cloudtrail_bucket = metadata['cloudtrail_bucket']
         self.behold_bucket = metadata['behold_bucket']
         self.region = metadata['region']
+        self.s3 = s3.S3(metadata, session)
         self.create_client(session)
 
     def active_resources(self):
@@ -81,6 +83,10 @@ class Athena():
                 "path": f"{path}/{execution_id}.csv"
             }
             self.active_roles_output_files.append(output_dict)
+            self.s3.check_object_exists(
+                bucket=self.behold_bucket,
+                key=f"{path}/{execution_id}.csv"
+            )
 
     def active_users_query(self):
         """ Runs query to determine which users have been used since days_back.
@@ -97,6 +103,10 @@ class Athena():
                 "path": f"{path}/{execution_id}.csv"
             }
             self.active_users_output_files.append(output_dict)
+            self.s3.check_object_exists(
+                bucket=self.behold_bucket,
+                key=f"{path}/{execution_id}.csv"
+            )
 
     def services_by_role_query(self, account, list_of_arns):
         """ Runs query to determine which services / actions have been used by a role.
@@ -119,6 +129,10 @@ class Athena():
                 "path": f"{path}/{execution_id}.csv"
             }
             self.services_by_role_output_files.append(output_dict)
+            self.s3.check_object_exists(
+                bucket=self.behold_bucket,
+                key=f"{path}/{execution_id}.csv"
+            )
 
     def services_by_user_query(self, account, list_of_arns):
         """ Runs query to determine which services / actions have been used by a role.
@@ -141,3 +155,7 @@ class Athena():
                 "path": f"{path}/{execution_id}.csv"
             }
             self.services_by_user_output_files.append(output_dict)
+            self.s3.check_object_exists(
+                bucket=self.behold_bucket,
+                key=f"{path}/{execution_id}.csv"
+            )

--- a/libs/athena.py
+++ b/libs/athena.py
@@ -114,7 +114,9 @@ class Athena():
         logger.info(f"Querying Athena for services used by role in {account}.")
         self.services_by_role_output_files = []
         for role_arn in list_of_arns:
-            role_name = role_arn.split('/')[1]
+            role_name = role_arn.split('/')
+            role_name = role_name[len(role_name) - 1]
+            logger.info(f"Querying by role: {role_name}")
             query_string, path = athena_query_strings.services_by_role(
                 account=account,
                 days_back=self.days_back,
@@ -141,6 +143,7 @@ class Athena():
         self.services_by_user_output_files = []
         for user_arn in list_of_arns:
             user_name = user_arn.split('/')[1]
+            logger.info(f"Querying by user: {user_name}")
             query_string, path = athena_query_strings.services_by_user(
                 account=account,
                 user_arn=user_arn,

--- a/libs/metadata.py
+++ b/libs/metadata.py
@@ -19,7 +19,6 @@ def read(filename):
         metadata = yaml.load(meta.read())
 
     validate_metadata(metadata)
-    metadata = set_defaults(metadata)
 
     return metadata
 
@@ -39,9 +38,10 @@ def validate_metadata(metadata):
                  "'behold_bucket' should be in the same region as your CloudTrail bucket.")
 
 
-def set_defaults(metadata):
+def set_defaults(metadata, boto=None):
     """ Sets defaults for non-required values if they are not specified in the metadata file. """
-    boto = utils.Boto(metadata)
+    if boto is None:
+        boto = utils.Boto(metadata)
     if 'years_to_partition' not in metadata:
         current_year = datetime.now().year
         logger.info(f"Setting 'years_to_partition' to {current_year}")

--- a/libs/s3.py
+++ b/libs/s3.py
@@ -8,19 +8,19 @@ logger = logging.getLogger(__name__)
 
 class S3():
     """ Class for interacting with S3 service in AWS. """
-    def __init__(self, metadata):
+    def __init__(self, metadata, session=None):
         """ Sets region and creates boto3 client. """
         self.region = metadata['region']
-        self.create_client()
+        self.create_client(session)
 
-    def create_client(self):
+    def create_client(self, session):
         """ Creates boto3 client as self.client. """
-        self.client = boto3.client('s3', region_name=self.region)
+        if session is None:
+            self.client = boto3.client('s3', region_name=self.region)
+        else:
+            self.client = session.client('s3')
 
-    def get_object(self, bucket, key):
-        """ Checks if object exists.  If it doesn't, wait half a second and check again.
-        Once the object is found it is downloaded."""
-        logger.info(f"Downloading {key} from {bucket}.")
+    def check_object_exists(self, bucket, key):
         obj_exists = False
         while not obj_exists:
             try:
@@ -31,6 +31,14 @@ class S3():
                 obj_exists = True
             except botocore.exceptions.ClientError:
                 time.sleep(.500)
+        return True
+
+    def get_object(self, bucket, key):
+        """ Checks if object exists.  If it doesn't, wait half a second and check again.
+        Once the object is found it is downloaded."""
+        logger.info(f"Downloading {key} from {bucket}.")
+
+        self.check_object_exists(bucket, key)
 
         obj = self.client.get_object(
             Bucket=bucket,

--- a/libs/s3.py
+++ b/libs/s3.py
@@ -11,6 +11,7 @@ class S3():
     def __init__(self, metadata, session=None):
         """ Sets region and creates boto3 client. """
         self.region = metadata['region']
+        self.metadata = metadata
         self.create_client(session)
 
     def create_client(self, session):


### PR DESCRIPTION
Ran into issues with S3 rate limiting when calling multiple Athena queries at once.  Making some changes so that only one Athena query runs at once by calling check_object_exists S3 method in the services_by_role/user functions.  